### PR TITLE
refractor/remove-gem-build: fix: Fix rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-require "bundler/gem_tasks"
 require "minitest/test_task"
-
-Minitest::TestTask.create
-
 require "rubocop/rake_task"
+
+Minitest::TestTask.create do |t|
+  t.test_globs = ["test/**/*_test.rb"]
+end
 
 RuboCop::RakeTask.new
 


### PR DESCRIPTION
### Changes in this PR:
```diff
diff --git a/Rakefile b/Rakefile
index 2bf771f..bef33a0 100644
--- a/Rakefile
+++ b/Rakefile
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
-require "bundler/gem_tasks"
 require "minitest/test_task"
-
-Minitest::TestTask.create
-
 require "rubocop/rake_task"
 
+Minitest::TestTask.create do |t|
+  t.test_globs = ["test/**/*_test.rb"]
+end
+
 RuboCop::RakeTask.new
 \n...(diff truncated for brevity)...
```

---
Files changed:
```
Rakefile
```
